### PR TITLE
fix: enhance AES-256-GCM availability check to include OpenSSL support

### DIFF
--- a/src/PacketHandler.php
+++ b/src/PacketHandler.php
@@ -61,7 +61,7 @@ class PacketHandler
         $this->stream = socket_export_stream($socket);
         stream_set_blocking($this->stream, false);
 
-        if (! sodium_crypto_aead_aes256gcm_is_available()) {
+        if (! sodium_crypto_aead_aes256gcm_is_available() && ! in_array('aes-256-gcm', openssl_get_cipher_methods())) {
             throw new \RuntimeException('AES-256-GCM not available');
         }
     }


### PR DESCRIPTION
### Problem
When running Whisp PHP on Apple Silicon (M1/M2/M3/M4) Macs, users encounter this error:
```
Fatal error: Uncaught RuntimeException: AES-256-GCM not available in PacketHandler.php:65
```

This occurs because `sodium_crypto_aead_aes256gcm_is_available()` returns `false` on Apple Silicon, even though the hardware and OpenSSL support AES-256-GCM operations. This is a known issue with libsodium on Apple Silicon architecture, as documented in [[this Apple Discussion thread](https://discussions.apple.com/thread/252923803)](https://discussions.apple.com/thread/252923803).

### Solution
This PR modifies the AES-256-GCM availability check to also consider OpenSSL's capabilities. Since the package already uses phpseclib3's AES implementation for the actual encryption/decryption operations, the Sodium check was unnecessarily restricting functionality on systems that can actually handle the encryption requirements.

The code now checks both Sodium and OpenSSL, allowing the library to function correctly on Apple Silicon Macs while maintaining compatibility with other architectures.

### Benefits
- Improves compatibility with Apple Silicon Macs
- Maintains security requirements by ensuring the encryption capability exists
- Minimal code change with no impact on existing functionality
- No need for users on Apple Silicon to implement workarounds

### Testing
The changes have been tested on an Apple Silicon Mac and confirm that the library operates correctly after this modification.